### PR TITLE
[17/02/2024]: Link unmatched documents to `Globals` category

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -37,11 +37,6 @@ function start() {
         description: "Global constructs",
     });
     const defaultCategory = new Category("Globals");
-    const defaultSubCategory = new SubCategory({
-        name: "default",
-        category: defaultCategory,
-    });
-    defaultCategory.subCategories.push(defaultSubCategory);
     categories.set(defaultCategory.name, defaultCategory);
 
     // Process each file
@@ -116,9 +111,7 @@ function start() {
             moduleDocs.forEach((doc) => fileModule!.addDoc(doc));
             const category =
                 fileModule.info.category?.name || defaultCategory.name;
-            const subCategory =
-                fileModule.info.category?.subCategory ||
-                defaultSubCategory.name;
+            const subCategory = fileModule.info.category?.subCategory;
             const categoryToAddTo = categories.get(category);
             const subCategoryToAddTo = categoryToAddTo?.subCategories.find(
                 (subCat) => subCat.name === subCategory,
@@ -155,7 +148,7 @@ function start() {
                                 module.info.name === fileModule!.info.name,
                         )
                 ) {
-                    defaultSubCategory.addModule(fileModule!);
+                    defaultCategory.addModule(fileModule!);
                 }
             }
 
@@ -171,6 +164,11 @@ function start() {
 
         defaultCategory.addModule(defaultFileModule);
     }
+
+    console.log({
+        defaultDocs: defaultFileModule.getDocs(),
+        defaultCategory: defaultCategory.name,
+    });
 
     // Generate documentation directory and files
     new Writer()

--- a/src/utils/writer.ts
+++ b/src/utils/writer.ts
@@ -126,13 +126,23 @@ export default class Writer {
                     });
                 }
 
-                // Collect chapters for Quarto YAML
-                const categoryChapters = category.subCategories.map(
-                    (subCategory) =>
-                        `chapters/${category.name}/${subCategory.name}/index.qmd`,
-                );
+                let categoryChapters: string[] = [];
+                if (category.subCategories.length === 0) {
+                    // Collect chapters for Quarto YAML
+                    categoryChapters = category
+                        .getModules()
+                        .map(
+                            (module) =>
+                                `chapters/${category.name}/${module.info.name}.qmd`,
+                        );
+                } else {
+                    // Collect chapters for Quarto YAML
+                    categoryChapters = category.subCategories.map(
+                        (subCategory) =>
+                            `chapters/${category.name}/${subCategory.name}/index.qmd`,
+                    );
+                }
 
-                // Group chapters under category
                 chapters.push({
                     part: category.name,
                     chapters: categoryChapters,


### PR DESCRIPTION
Fixes #20 

All documentation generated from each file should be linked to a `category` or `subcategory`. If they have no parent category or subcategory, they should be pushed to the default category `Globals`. 

Before now, this feature did not work as expected. This PR fixes this