### PR TITLE
List English only once

### DIFF
--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -51,7 +51,6 @@ babelquarto:
       text: Version in fr
   mainlanguage: en
   languages:
-    - en
     - ar
     - es
     - fr


### PR DESCRIPTION
It's the mainlanguage so shouldn't be listed under languages.

I agree the field names are not the best. :sweat_smile:

