### PR TITLE
[02/05/2024] Reference default config from `config.json` when cli args are not specified

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -4,6 +4,8 @@ const CONFIG = {
     outputDirectory: config.outputDirectory,
     sourceDirectory: config.sourceDirectory,
     tutorialDirectory: config.tutorialDirectory,
+    languages: config.languages,
+    includeLocalizedVersions: config.includeLocalizedVersions,
 }
 
 export default CONFIG;

--- a/src/index.ts
+++ b/src/index.ts
@@ -61,7 +61,7 @@ function getJSFilesFromDirectory(
  *
  * @returns void
  */
-async function start(localizationConfig?: { languages: string[], includeLocalizedVersions?: boolean }) {
+async function start() {
     // Get JavaScript files from directory
     const filePaths = getJSFilesFromDirectory(CONFIG.sourceDirectory);
 
@@ -198,12 +198,12 @@ async function start(localizationConfig?: { languages: string[], includeLocalize
     const chapters = await writer.addTutorialsToGeneratedDoc();
     await writer.addTutorialChaptersToQuartoYml(chapters);
 
-    if (localizationConfig?.languages) {
+    if (CONFIG.languages) {
         console.log("Running with languages");
-        writer.addLanguageSpecsToQuartoConfig(localizationConfig.languages);
+        writer.addLanguageSpecsToQuartoConfig(CONFIG.languages);
 
-        if (localizationConfig?.includeLocalizedVersions) {
-            writer.createLocalizedFilesForEachLanguage(localizationConfig.languages);
+        if (CONFIG.includeLocalizedVersions) {
+            writer.createLocalizedFilesForEachLanguage(CONFIG.languages);
         }
     }
 
@@ -249,6 +249,8 @@ CONFIG.outputDirectory =
             : path.join(__dirname, `/../${specifiedOutputDirectory}`)
         : CONFIG.outputDirectory;
 
-console.log({ CONFIG })
+CONFIG.includeLocalizedVersions = includeLocalizedVersions ? true : CONFIG.includeLocalizedVersions;
 
-start({ languages: specifiedLanguages ?? ['en'], includeLocalizedVersions: !!includeLocalizedVersions });
+CONFIG.languages = specifiedLanguages ?? CONFIG.languages;
+
+start();

--- a/src/index.ts
+++ b/src/index.ts
@@ -233,21 +233,21 @@ CONFIG.sourceDirectory =
         ? specifiedSourceFilesDirectory.startsWith("/")
             ? specifiedSourceFilesDirectory
             : path.join(__dirname, `/../${specifiedSourceFilesDirectory}`)
-        : __dirname + `/../source_files`;
+        : CONFIG.sourceDirectory;
 
 CONFIG.tutorialDirectory =
     specifiedTutorialsDirectory
         ? specifiedTutorialsDirectory.startsWith("/")
             ? specifiedTutorialsDirectory
             : path.join(__dirname, `/../${specifiedTutorialsDirectory}`)
-        : __dirname + `/../tutorials`;
+        : CONFIG.tutorialDirectory;
 
 CONFIG.outputDirectory =
     specifiedOutputDirectory
         ? specifiedOutputDirectory.startsWith("/")
             ? specifiedOutputDirectory
             : path.join(__dirname, `/../${specifiedOutputDirectory}`)
-        : __dirname + `/../docs`;
+        : CONFIG.outputDirectory;
 
 console.log({ CONFIG })
 


### PR DESCRIPTION
When the --source argument is not specified when generating the doc, it is expected to search reference the default values.

It behaves as expected, but this default value isn't referenced from the config, it is hardcoded.


<!--
Please complete the following sections when you submit your pull request. You are encouraged to keep this top level comment box updated as you develop and respond to reviews. Note that text within html comment tags will not be rendered.
-->
### Summary

<!-- Describe the problem you're trying to fix in this pull request. Please reference any related issue and use fixes/close to automatically close them, if pertinent. For example: "Fixes #58", or "Addresses (but does not close) #238". -->
When CLI arg like `--source` `--tutorial` are not specified it's expected to reference the default values set in the `config.json` instead of using hardcoded values

### List of changes proposed in this PR (pull-request)
* *Remove reference to hardcoded values for configurations*
* *Reference defaults in `config.json`*
* *Add `languages` and `includeLocalizedVersions` to config*
