### PR TITLE
[22/05/2024] feat: add right-to-left styling for arabic docs

### DIFF
--- a/src/fixes/fix_rtl.ts
+++ b/src/fixes/fix_rtl.ts
@@ -1,0 +1,69 @@
+import * as Cheerio from "cheerio";
+import fs from "fs";
+import logger from "../utils/logger";
+import path from "path";
+import CONFIG from "../config";
+
+async function processHtmlFilesInDirectory(
+    directory: string,
+    cssContent: string,
+) {
+    const files = await fs.promises.readdir(directory, { withFileTypes: true });
+
+    for (const file of files) {
+        const filePath = path.join(directory, file.name);
+
+        if (file.isDirectory()) {
+            // Recursively process subdirectories
+            await processHtmlFilesInDirectory(filePath, cssContent);
+        } else if (file.isFile() && file.name.endsWith(".html")) {
+            await processHtmlFile(filePath, cssContent);
+        }
+    }
+}
+
+async function processHtmlFile(filePath: string, cssContent: string) {
+    logger.info(`Reading file: ${filePath}`);
+
+    const htmlContent = await fs.promises.readFile(filePath, "utf-8");
+    logger.info(`Finished reading file: ${filePath}`);
+
+    const $ = Cheerio.load(htmlContent);
+
+    // Add the CSS content into a <style> tag in the head of the HTML file
+    $("head").append(`<style>${cssContent}</style>`);
+
+    await fs.promises.writeFile(filePath, $.html());
+    logger.info(`Finished processing file: ${filePath}`);
+}
+
+export async function fixAndStyleArabicHtmlFiles() {
+    if (!CONFIG.languages.includes("ar")) {
+        logger.info("Arabic language not found in the list of languages");
+        return;
+    }
+
+    const directoryForHtmlFiles = path.join(CONFIG.outputDirectory, `_book/ar/`);
+    const cssFilePath = path.join(__dirname, "/rtl.css");
+
+    // Read the CSS file
+    const cssContent = await fs.promises.readFile(cssFilePath, "utf-8");
+
+    // Start processing from the root directory
+    await processHtmlFilesInDirectory(directoryForHtmlFiles, cssContent);
+}
+
+if (require.main === module) {
+    const langs = process.argv
+        .find((arg) => arg.startsWith("languages"))
+        ?.split("=")[1]
+        ?.split(",");
+
+    if (!langs) {
+        console.warn(
+            "Languages not specified in cli arguments, setting languages to default",
+        );
+    }
+
+    fixAndStyleArabicHtmlFiles();
+}

--- a/src/fixes/index.ts
+++ b/src/fixes/index.ts
@@ -1,6 +1,7 @@
 import CONFIG from "../config";
 import { fixDuplicateLanguageReferences } from "./fix_duplicate_language_refs";
 import { fixLocalizedIndexFiles } from "./fix_localized_index_file";
+import { fixAndStyleArabicHtmlFiles } from "./fix_rtl";
 import { fixWrongLanguageReferences } from "./fix_wrong_language_refs";
 
 async function start() {
@@ -20,6 +21,7 @@ async function start() {
     await fixLocalizedIndexFiles();
     await fixDuplicateLanguageReferences();
     await fixWrongLanguageReferences();
+    await fixAndStyleArabicHtmlFiles()
 }
 
 start();

--- a/src/fixes/rtl.css
+++ b/src/fixes/rtl.css
@@ -1,0 +1,155 @@
+/*--------------------------------------------------------------------*\
+
+This file contains the CSS that handles styling across the entire book.
+Use the classes defined here to control the look of HTML elements in your contribution.
+
+If you add new styles, remember explain what it does as shown below.
+
+Index
+  - Styling for Table of Contents
+  - Styling for Embedded Videos
+
+\*--------------------------------------------------------------------*/
+
+/*--------------------------------------------------------------------*\
+Styling for Table of Contents
+
+- Ensures that menu items in the table of contents are big enough for readers
+
+\*--------------------------------------------------------------------*/
+
+@import url("https://fonts.googleapis.com/css2?family=Noto+Sans+Arabic:wght@100;200;300;400;500;600;700;800&display=swap");
+
+div {
+    direction: rtl;
+}
+
+body {
+    text-align: right;
+    font-family: "Noto Sans Arabic", sans-serif;
+}
+
+h1 {
+    font-family: "Noto Sans Arabic", sans-serif;
+    font-weight: 500;
+    color: blue;
+
+    /* color: #757474; */
+}
+
+h2 {
+    font-family: "Noto Sans Arabic", sans-serif;
+    font-weight: 400;
+    /* color: #757474; */
+}
+
+h3 {
+    font-family: "Noto Sans Arabic", sans-serif;
+    font-weight: 400;
+    /* color: #757474; */
+}
+
+#site-navigation li > a {
+    font-size: 1.1em;
+}
+
+/*--------------------------------------------------------------------*\
+
+Styling for Embedded Videos (iframes)
+
+- Ensures that videos can resize to suit the screen the book is read from.
+- Also ensures that videos are horizontally centered.
+
+\*--------------------------------------------------------------------*/
+
+.video-container {
+    position: relative;
+    padding-bottom: 56.25%;
+    padding-top: 35px;
+    height: 0;
+    overflow: hidden;
+}
+
+.video-container iframe {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+}
+
+iframe {
+    margin: auto;
+    display: block;
+}
+
+/*--------------------------------------------------------------------*\
+
+Styling for Tables
+
+- Improves styling of tables over the default Markdown standard
+- Adds borders to tables, and allows a rows to be highlighted when hovered
+
+\*--------------------------------------------------------------------*/
+
+th,
+td {
+    border: 1px solid #999999 !important;
+    text-align: center;
+    padding: 10px;
+}
+
+th {
+    font-weight: bold;
+    background-color: #eeeeee;
+}
+
+table caption {
+    color: black;
+    text-align: center;
+}
+
+table caption .footnote {
+    color: #666666;
+    text-align: left;
+    font-size: smaller;
+}
+
+tr:hover {
+    background-color: #f7f7f7;
+}
+
+div {
+    direction: rtl;
+}
+
+body {
+    direction: rtl;
+}
+
+h1 {
+    direction: rtl;
+}
+
+h2 {
+    direction: rtl;
+}
+
+h3 {
+    direction: rtl;
+}
+
+body {
+    background: #fff;
+    color: #666666;
+    family: "IBM Plex Sans Arabic", sans-serif;
+}
+
+.caption-number {
+    direction: rtl;
+    text-align: right;
+}
+
+.fa-angle-right {
+    transform: rotate(180deg);
+}


### PR DESCRIPTION
<!--
Please complete the following sections when you submit your pull request. You are encouraged to keep this top level comment box updated as you develop and respond to reviews. Note that text within html comment tags will not be rendered.
-->
### Summary

<!-- Describe the problem you're trying to fix in this pull request. Please reference any related issue and use fixes/close to automatically close them, if pertinent. For example: "Fixes #58", or "Addresses (but does not close) #238". -->
Display arabic documents in `right-to-left` format

### List of changes proposed in this PR (pull-request)
* *Add styling for rtl docs*
* *Add script to include the styling in all arabic docs generated*
* *Include script in ci flow*
