### PR TITLE
[06/23/2024]: Feat - Store path to project config

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oscsa/jsquarto",
-    "version": "1.0.2",
+    "version": "1.0.3",
     "description": "Generate JS package API reference documentation using Markdown and Quarto. JSquarto is designed as an alternative to JSDoc",
     "main": "index.js",
     "scripts": {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -107,4 +107,7 @@ JSQuarto is developed and maintained by the [Open Science Community Saudi Arabia
 ## Feedback and Support
 If you have any questions, feedback, or need support, please [open an issue](https://github.com/Open-Science-Community-Saudi-Arabia/JSquarto/issues) on GitHub or [join our community](https://github.com/Open-Science-Community-Saudi-Arabia) for assistance.`;
 
-export const CONFIG_STORE_PATH = path.join(__dirname, "./store/paths.json");
+export const PROJECTS_CONFIG_STORE_PATH = path.join(
+    __dirname,
+    "./store/paths.json",
+);

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -104,3 +104,5 @@ JSQuarto is developed and maintained by the [Open Science Community Saudi Arabia
 
 ## Feedback and Support
 If you have any questions, feedback, or need support, please [open an issue](https://github.com/Open-Science-Community-Saudi-Arabia/JSquarto/issues) on GitHub or [join our community](https://github.com/Open-Science-Community-Saudi-Arabia) for assistance.`;
+
+export const PROJECTS_CONFIG_STORE_PATH = path.join(__dirname, "./store/paths.json");

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,3 +1,5 @@
+import path from "path";
+
 export const DEFAULT_QUARTO_YAML_CONTENT = {
     project: {
         type: "book",
@@ -105,4 +107,4 @@ JSQuarto is developed and maintained by the [Open Science Community Saudi Arabia
 ## Feedback and Support
 If you have any questions, feedback, or need support, please [open an issue](https://github.com/Open-Science-Community-Saudi-Arabia/JSquarto/issues) on GitHub or [join our community](https://github.com/Open-Science-Community-Saudi-Arabia) for assistance.`;
 
-export const PROJECTS_CONFIG_STORE_PATH = path.join(__dirname, "./store/paths.json");
+export const CONFIG_STORE_PATH = path.join(__dirname, "./store/paths.json");

--- a/src/scripts/config.ts
+++ b/src/scripts/config.ts
@@ -9,7 +9,7 @@ switch (command) {
         ConfigMgr.initializeConfigFile();
         break;
     case "set":
-        ConfigMgr.setConfigInFile();
+        ConfigMgr.writeConfigToFile();
         break;
     case "get":
         // const configValue = ConfigMgr.getConfigValue();

--- a/src/store/paths.json
+++ b/src/store/paths.json
@@ -1,0 +1,8 @@
+{
+    "paths": [
+        {
+            "projectDir": "/",
+            "configDir": "/"
+        }
+    ]
+}

--- a/src/utils/config_mgr.ts
+++ b/src/utils/config_mgr.ts
@@ -433,6 +433,13 @@ export default class ConfigMgr {
             },
         });
 
+        // Remove cli commands from keys
+        config = Object.fromEntries(
+            Object.entries(config).filter(
+                ([key, _]) => !key.includes("config") && !key.includes("force"),
+            ),
+        );
+
         fs.writeFileSync(configPath, JSON.stringify(config, null, 4));
         logger.info("Config file written successfully");
     }

--- a/src/utils/config_mgr.ts
+++ b/src/utils/config_mgr.ts
@@ -366,9 +366,17 @@ export default class ConfigMgr {
         logger.info("Config file written successfully");
     }
 
-    static getConfig() {
-        this.updateConfigStore();
-        return this.CONFIG;
+    static getConfig(): Config {
+        let config = DEFAULT_CONFIG;
+
+        if (this.configHasBeenUpdated) {
+            config = { ...config, ...this.CONFIG };
+        } else {
+            const updatedConfig = this.updateConfigStore().config;
+            config = { ...config, ...updatedConfig };
+        }
+
+        return config;
     }
 }
 

--- a/src/utils/config_mgr.ts
+++ b/src/utils/config_mgr.ts
@@ -116,7 +116,6 @@ export default class ConfigMgr {
         projectDir,
     }: {
         projectDir: string;
-        configDir: string;
     }) {
         if (this.projectConfigPaths) {
             return this.projectConfigPaths.find(
@@ -314,6 +313,19 @@ export default class ConfigMgr {
 
         fs.writeFileSync(configPath, JSON.stringify(updatedConfig, null, 4));
         logger.info("Config file written successfully");
+
+        // Add config file and project path to store
+        const { projectDir, configDir } =
+            await this.updateProjectPathsToConfigRecord({
+                projectDir: currentWorkingDirectory,
+                configDir: configPath,
+            });
+
+        return {
+            projectDir,
+            configDir,
+            config: updatedConfig,
+        };
     }
 
     static async writeConfigToFile() {

--- a/src/utils/config_mgr.ts
+++ b/src/utils/config_mgr.ts
@@ -182,7 +182,7 @@ export default class ConfigMgr {
 
         const configFileExists = fs.existsSync(projectConfig.configDir);
         if (!configFileExists) {
-            logger.error("No config file found for project");
+            logger.error("Config path in store but file doesn't exist");
             process.exit(1);
         }
 

--- a/src/utils/config_mgr.ts
+++ b/src/utils/config_mgr.ts
@@ -384,20 +384,25 @@ export default class ConfigMgr {
             configFileAlreadyExists,
         });
         // If it's a directory, that means the user wants to initialize a new config file
-        if (configFileAlreadyExists) {
+        // Default config can exists in cases where it was initialized from another device or manually created
+        // In this case the store wouldn't have a record of it
+        if (configFileAlreadyExists || configExistsInDefaultPath) {
             const forceOverwrite = cliArgument.has("force");
             if (!forceOverwrite) {
-                configFileFromArgsExists
-                    ? logger.error(
-                          `An existing config file was found at ${configPath} Use the --force flag to overwrite`,
-                      )
-                    : logger.error(
-                          `An existing record was set for ${configFileInStore} Use the --force flag to overwrite the current record`,
-                      );
+                let msg = "";
+                if (configFileFromArgsExists || configExistsInDefaultPath) {
+                    msg = `An existing config file was found at ${configPath ?? defaultConfigPath}`;
+                } else {
+                    msg = `An existing record was set for ${configFileInStore ?? defaultConfigPath}`;
+                }
+                logger.error(
+                    msg +
+                        `\n Run 'jsq config:init --force' to overwrite the current record or \n Run 'jsq config:set --config <path>' to set a new config file path
+                             `,
+                );
                 process.exit(1);
             }
 
-            // TODO: Ask for confirmation before overwriting
             logger.warn("Overwriting existing config file...");
         }
 

--- a/src/utils/config_mgr.ts
+++ b/src/utils/config_mgr.ts
@@ -169,11 +169,7 @@ export default class ConfigMgr {
         };
     }
 
-    private static async getConfigForProject({
-        projectDir,
-    }: {
-        projectDir: string;
-    }) {
+    private static getConfigForProject({ projectDir }: { projectDir: string }) {
         const projectConfig = this.getProjectConfigPath({ projectDir });
         if (!projectConfig || !projectConfig.configDir) {
             logger.warn("No config found for project");
@@ -182,8 +178,8 @@ export default class ConfigMgr {
 
         const configFileExists = fs.existsSync(projectConfig.configDir);
         if (!configFileExists) {
-            logger.error("Config path in store but file doesn't exist");
-            process.exit(1);
+            logger.warn("Config path in store but file doesn't exist");
+            return {};
         }
 
         const configFile = fs.readFileSync(projectConfig.configDir, "utf-8");
@@ -309,7 +305,7 @@ export default class ConfigMgr {
         };
     }
 
-    static async initializeConfigFile() {
+    static initializeConfigFile() {
         const cliArgument = CliArgParser.getArgs();
 
         const currentWorkingDirectory = cliArgument.get("workingDirectory");
@@ -412,24 +408,21 @@ export default class ConfigMgr {
         const configFileExists = configPath && fs.existsSync(configPath);
 
         // Check if user is trying to set the path to a new config file
-        if (!configPath && !configFileExists) {
-            // Check if user is trying to set the path to a new config file
-            const configPathFromArgs = cliArgs.get("config");
-            if (configPathFromArgs) {
-                configPath = path.isAbsolute(configPathFromArgs)
-                    ? path.resolve(configPathFromArgs)
-                    : path.resolve(workingDir, configPathFromArgs);
+        const configPathFromArgs = cliArgs.get("config");
+        if (configPathFromArgs) {
+            configPath = path.isAbsolute(configPathFromArgs)
+                ? path.resolve(configPathFromArgs)
+                : path.resolve(workingDir, configPathFromArgs);
 
-                const configFileExists = fs.existsSync(configPath);
-                if (!configFileExists) {
-                    throw new Error("No config file found at specified path");
-                }
-
-                this.addProjectConfigPathToStore({
-                    projectDir: workingDir,
-                    configDir: configPath,
-                });
+            const configFileExists = fs.existsSync(configPath);
+            if (!configFileExists) {
+                throw new Error("No config file found at specified path");
             }
+
+            this.addProjectConfigPathToStore({
+                projectDir: workingDir,
+                configDir: configPath,
+            });
         }
 
         configPath = configFileExists

--- a/src/utils/config_mgr.ts
+++ b/src/utils/config_mgr.ts
@@ -320,13 +320,13 @@ export default class ConfigMgr {
                 : path.resolve(currentWorkingDirectory, configPath)
             : null;
 
-        const updatedConfig = this.updateConfigStore().config;
-
-        logger.info("Writing updated config to file...", {
-            meta: {
-                updatedConfig,
-            },
-        });
+        // const updatedConfig = this.updateConfigStore().config;
+        //
+        // logger.info("Writing updated config to file...", {
+        //     meta: {
+        //         updatedConfig,
+        //     },
+        // });
 
         const projectConfigPathSavedInStore = this.getProjectConfigPath({
             projectDir: currentWorkingDirectory,
@@ -378,11 +378,7 @@ export default class ConfigMgr {
                 recursive: true,
             });
 
-        fs.writeFileSync(configPath, JSON.stringify(updatedConfig, null, 4));
-        logger.info("Config file written successfully");
-
-        // Add config file and project path to store
-        const { projectDir } = await this.addProjectConfigPathToStore({
+        const { projectDir } = this.addProjectConfigPathToStore({
             projectDir: currentWorkingDirectory,
             configDir: configPath,
         });

--- a/src/utils/config_mgr.ts
+++ b/src/utils/config_mgr.ts
@@ -160,9 +160,21 @@ export default class ConfigMgr {
     }
 
     static updateConfigStore(): { config: Config; inputData: Partial<Config> } {
-        const cliArgs = this.getArgsFromCli();
+        const cliArgs = CliArgParser.getArgs();
+        const workingDir = cliArgs.get("workingDirectory");
+        if (!workingDir) {
+            logger.error("No working directory provided");
+            process.exit(1);
+        }
 
-        const currentConfig = this.CONFIG;
+        this.currentWorkingDirectory = workingDir;
+
+        const currentConfig = {
+            ...this.CONFIG,
+            ...this.getConfigForProject({ projectDir: workingDir }),
+        };
+
+        // Extract data to update
         const configToUpdate = {} as Config;
         for (const entries of cliArgs.entries()) {
             const [cliKey, cliValue] = entries as [

--- a/src/utils/config_mgr.ts
+++ b/src/utils/config_mgr.ts
@@ -224,8 +224,8 @@ export default class ConfigMgr {
             const _key = this.configMap[cliKey];
 
             if (_key === "includeLocalizedVersions" || _key === "force") {
-                console.log({ equal: cliValue === "true" });
-                configToUpdate[_key] = (cliValue as unknown) != false;
+                console.log({ equal: cliValue === "true", cliValue });
+                configToUpdate[_key] = cliValue != "false";
                 continue;
             }
 
@@ -406,6 +406,8 @@ export default class ConfigMgr {
             logger.error("No working directory provided");
             process.exit(1);
         }
+
+        this.currentWorkingDirectory = workingDir
 
         let configPath = this.getProjectConfigPath({
             projectDir: workingDir,

--- a/src/utils/config_mgr.ts
+++ b/src/utils/config_mgr.ts
@@ -156,8 +156,8 @@ export default class ConfigMgr {
     }) {
         const projectConfig = this.getProjectConfigPath({ projectDir });
         if (!projectConfig || !projectConfig.configDir) {
-            logger.error("No config found for project");
-            process.exit(1);
+            logger.warn("No config found for project");
+            return {};
         }
 
         const configFileExists = fs.existsSync(projectConfig.configDir);

--- a/src/utils/config_mgr.ts
+++ b/src/utils/config_mgr.ts
@@ -30,17 +30,27 @@ interface ProjectConfig {
 
 type CliArgs = Partial<{ [k in keyof ConfigMap]: string }>;
 
+const DEFAULT_CONFIG = {
+    outputDirectory: config.outputDirectory,
+    sourceDirectory: config.sourceDirectory,
+    tutorialDirectory: config.tutorialDirectory,
+    translationsDirectory: config.translationsDirectory,
+    includeLocalizedVersions: config.includeLocalizedVersions,
+    languages: config.languages,
+};
 export default class ConfigMgr {
-    private static CONFIG = {
-        outputDirectory: config.outputDirectory,
-        sourceDirectory: config.sourceDirectory,
-        tutorialDirectory: config.tutorialDirectory,
-        translationsDirectory: config.translationsDirectory,
-        includeLocalizedVersions: config.includeLocalizedVersions,
-        languages: config.languages,
-    } as Config;
+    private static CONFIG = DEFAULT_CONFIG as Config;
+    private static configHasBeenUpdated = false;
     private static currentWorkingDirectory: string;
     private static projectConfigPaths: ProjectConfig["paths"] | null = null;
+    static configMap: ConfigMap = {
+        source: "sourceDirectory",
+        output: "outputDirectory",
+        tutorial: "tutorialDirectory",
+        include_localized_versions: "includeLocalizedVersions",
+        languages: "languages",
+        translations: "translationsDirectory",
+    } as const;
 
     private static async updateProjectPathsToConfigRecord({
         projectDir,

--- a/src/utils/config_mgr.ts
+++ b/src/utils/config_mgr.ts
@@ -136,27 +136,27 @@ export default class ConfigMgr {
         };
     }
 
-    // keys are the cli arguments, values are the config keys
-    static configMap: ConfigMap = {
-        source: "sourceDirectory",
-        output: "outputDirectory",
-        tutorial: "tutorialDirectory",
-        include_localized_versions: "includeLocalizedVersions",
-        languages: "languages",
-        translations: "translationsDirectory",
-    } as const;
-
-    static getArgsFromCli() {
-        const cliArguments = CliArgParser.getArgs();
-        const workingDir = cliArguments.get("workingDirectory");
-        if (!workingDir) {
-            logger.error("No working directory provided");
+    private static async getConfigForProject({
+        projectDir,
+    }: {
+        projectDir: string;
+    }) {
+        const projectConfig = this.getProjectConfigPath({ projectDir });
+        if (!projectConfig || !projectConfig.configDir) {
+            logger.error("No config found for project");
             process.exit(1);
         }
 
-        this.currentWorkingDirectory = workingDir;
+        const configFileExists = fs.existsSync(projectConfig.configDir);
+        if (!configFileExists) {
+            logger.error("No config file found for project");
+            process.exit(1);
+        }
 
-        return cliArguments;
+        const configFile = fs.readFileSync(projectConfig.configDir, "utf-8");
+        const config = JSON.parse(configFile) as Config;
+
+        return config;
     }
 
     static updateConfigStore(): { config: Config; inputData: Partial<Config> } {

--- a/src/utils/config_mgr.ts
+++ b/src/utils/config_mgr.ts
@@ -4,6 +4,7 @@ import config from "../../config.json";
 import CliArgParser from "./arg-parser";
 import path from "path";
 import fs from "fs";
+import { PROJECTS_CONFIG_STORE_PATH } from "../constants";
 
 export interface Config {
     outputDirectory: string;
@@ -21,6 +22,10 @@ export interface ConfigMap {
     include_localized_versions: "includeLocalizedVersions";
     languages: "languages";
     translations: "translationsDirectory";
+}
+
+interface ProjectConfig {
+    paths: { projectDir: string; configDir: string }[];
 }
 
 type CliArgs = Partial<{ [k in keyof ConfigMap]: string }>;

--- a/src/utils/config_mgr.ts
+++ b/src/utils/config_mgr.ts
@@ -395,12 +395,10 @@ export default class ConfigMgr {
                 } else {
                     msg = `An existing record was set for ${configFileInStore ?? defaultConfigPath}`;
                 }
-                logger.error(
-                    msg +
-                        `\n Run 'jsq config:init --force' to overwrite the current record or \n Run 'jsq config:set --config <path>' to set a new config file path
-                             `,
-                );
-                process.exit(1);
+                msg +=
+                    `\n Run 'jsq config:init --force' to overwrite the current record or \n Run 'jsq config:set --config <path>' to set a new config file path
+                             `;
+                throw new Error(msg);
             }
 
             logger.warn("Overwriting existing config file...");

--- a/src/utils/config_mgr.ts
+++ b/src/utils/config_mgr.ts
@@ -447,6 +447,10 @@ export default class ConfigMgr {
     static getConfig(): Config {
         let config = DEFAULT_CONFIG;
 
+        const configForProject = this.getConfigForProject({
+            projectDir: this.currentWorkingDirectory,
+        });
+
         if (this.configHasBeenUpdated) {
             config = { ...config, ...this.CONFIG };
         } else {
@@ -454,7 +458,7 @@ export default class ConfigMgr {
             config = { ...config, ...updatedConfig };
         }
 
-        return config;
+        return { ...config, ...configForProject };
     }
 }
 

--- a/src/utils/config_mgr.ts
+++ b/src/utils/config_mgr.ts
@@ -85,9 +85,31 @@ export default class ConfigMgr {
         projectDir: string;
         configDir: string;
     }) {
+        if (this.projectConfigPaths) {
+            return this.projectConfigPaths.find(
+                (config) => config.projectDir === projectDir,
+            );
+        }
+
+        const storeExists = fs.existsSync(PROJECTS_CONFIG_STORE_PATH);
+        if (!storeExists) {
+            logger.error("No config store found");
+            process.exit(1);
+        }
+
+        const configStore = fs.readFileSync(
+            PROJECTS_CONFIG_STORE_PATH,
+            "utf-8",
+        );
+        const config = JSON.parse(configStore) as ProjectConfig;
+
+        this.projectConfigPaths = config.paths;
+
         return {
             projectDir,
-            configDir: "",
+            configDir: config.paths.find(
+                (config) => config.projectDir === projectDir,
+            )?.configDir,
         };
     }
 

--- a/src/utils/config_mgr.ts
+++ b/src/utils/config_mgr.ts
@@ -84,8 +84,28 @@ export default class ConfigMgr {
             } as ProjectConfig;
         }
 
+        // Check if project path already exists in store
+        const projectPathExists = config.paths.some(
+            (path: { projectDir: string }) => path.projectDir === projectDir,
+        );
+        if (projectPathExists) {
+            logger.warn("Project path already exists in store, updating...");
+            const projectIndex = config.paths.findIndex(
+                (path: { projectDir: string }) =>
+                    path.projectDir === projectDir,
+            );
+
+            config.paths[projectIndex] = {
+                projectDir,
+                configDir,
+            };
+        } else {
+            logger.info("Adding project path to store...");
+            config.paths.push({ projectDir, configDir });
+        }
+
         const updatedConfig = {
-            paths: [...config.paths, { projectDir, configDir }],
+            paths: config.paths,
         };
 
         logger.info("Updating config store...", {

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -16,12 +16,28 @@
  * */
 
 import winston from "winston";
+import util from "util";
+
+const logFormat = winston.format.printf((info) => {
+    let message = info.message;
+
+    if (typeof message === "object") {
+        message = util.inspect(message, { depth: null });
+    }
+
+    const logMeta = info.meta ? util.inspect(info.meta, { depth: null }) : "";
+    return info.meta
+        ? `[${info.timestamp}] | ${info.level}: ${message} ${logMeta}`
+        : `[${info.timestamp}] | ${info.level}: ${message}`;
+});
 
 const logger = winston.createLogger({
     level: "info",
     format: winston.format.combine(
         winston.format.colorize(),
+        winston.format.timestamp(),
         winston.format.simple(),
+        logFormat,
     ),
     transports: [new winston.transports.Console()],
 });


### PR DESCRIPTION
<!--
Please complete the following sections when you submit your pull request. You are encouraged to keep this top level comment box updated as you develop and respond to reviews. Note that text within html comment tags will not be rendered.
-->
### Summary
<!-- Describe the problem you're trying to fix in this pull request. Please reference any related issue and use fixes/close to automatically close them, if pertinent. For example: "Fixes #58", or "Addresses (but does not close) #238". -->

This feature allows users set the path to thier `config.json` file directly from the cli using `jsq config:set config=<path to config file>`.

### Commands added
- `config:init` - Initializes new config file in project folder
- `config:set` - Update config values in config file, can also be used to point Jsquarto to a new config file for the project

### List of changes proposed in this PR (pull-request)
 - [x] Specify path to config file in any project
 - [x] The config in that path should be used whenever a jsq command is run within the project
 - [ ] Find a way to reference the config if even if you're in a subdirectory of the project
 - [ ] Add detailed doc on usage for new commands
